### PR TITLE
implement ConnectionHub: a system for maintaining unique persistent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ docker build . -t mllparty
 docker run --rm --env API_KEY="sekret" --env SECRET_KEY_BASE="$(mix phx.gen.secret)" -p 4000:4000 mllparty
 ```
 
+### Persistent Connections
+
+MLLP client connections will attempt to stay alive and connected, not just during the HTTP request lifecycle.
+
+If there's no client connection for the IP/Port specified in a given HTTP API request, a client connection process will be started for that endpoint.
+
+Additionally, you can start some persistent client connections on boot with the `BOOT_CONNECTIONS` env variable.
+
+**Example:**
+```
+docker run --rm --env BOOT_CONNECTIONS="127.0.0.1:6090,127.0.0.1:6091" -p 4000:4000 mllparty
+```
+
+To query for current connections:
+```
+curl http://localhost:4000/api/connections \
+    -u ":sekret" \
+    -H "Content-Type: application/json"
+```
+
 
 ### Mix Task
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,6 +51,16 @@ if config_env() == :prod do
     ],
     secret_key_base: secret_key_base
 
+  boot_connections =
+    System.get_env("BOOT_CONNECTIONS", "")
+    |> String.split(",")
+    |> Enum.map(fn ip_port ->
+      [ip, port] = String.split(ip_port, ":")
+      {ip, String.to_integer(port)}
+    end)
+
+  config :mllparty, boot_connections: boot_connections
+
   # ## SSL Support
   #
   # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,8 @@
 import Config
 
+config :mllparty,
+  default_connection_wait_time: 1000
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :mllparty, MLLPartyWeb.Endpoint,

--- a/lib/mix/tasks/send_mllp.ex
+++ b/lib/mix/tasks/send_mllp.ex
@@ -15,29 +15,14 @@ defmodule Mix.Tasks.SendMllp do
     run(["mllp://" <> endpoint, HL7.Examples.wikipedia_sample_hl7()])
   end
 
-  # Map of persistent connections (endpoint => client pid)
-  # Example { "127.0.0.1:3000" => #PID<1>, "127.0.0.1:4000" => #PID<2> }
-  @connections %{}
-
   def run(["mllp://" <> endpoint, message]) do
     [ip, port] = String.split(endpoint, ":")
     port = String.to_integer(port)
     message = HL7.Message.new(message)
 
-    # Check for an existing client for this endpoint
-    if Map.has_key?(@connections, endpoint) do
-      # Reconnect to the endpoint, if needed
-      unless MLLP.Client.is_connected?(@connections[endpoint]) do
-        MLLP.Client.reconnect(@connections[endpoint])
-      end
-    else
-      # Make a new connection
-      {:ok, client_pid} = MLLP.Client.start_link(ip, port)
-      @connections = Map.put(@connections, endpoint, client_pid)
-    end
-
     # Send message to the endpoint
-    resp = MLLP.Client.send(@connections[endpoint], message)
+    resp =
+      MLLParty.ConnectionHub.send_message(ip, port, message, wait_for_client_to_connect: true)
 
     Mix.shell().info(inspect(resp))
   end

--- a/lib/mix/tasks/send_mllp.ex
+++ b/lib/mix/tasks/send_mllp.ex
@@ -15,13 +15,29 @@ defmodule Mix.Tasks.SendMllp do
     run(["mllp://" <> endpoint, HL7.Examples.wikipedia_sample_hl7()])
   end
 
+  # Map of persistent connections (endpoint => client pid)
+  # Example { "127.0.0.1:3000" => #PID<1>, "127.0.0.1:4000" => #PID<2> }
+  @connections %{}
+
   def run(["mllp://" <> endpoint, message]) do
     [ip, port] = String.split(endpoint, ":")
     port = String.to_integer(port)
     message = HL7.Message.new(message)
 
-    {:ok, s1} = MLLP.Client.start_link(ip, port)
-    resp = MLLP.Client.send(s1, message)
+    # Check for an existing client for this endpoint
+    if Map.has_key?(@connections, endpoint) do
+      # Reconnect to the endpoint, if needed
+      unless MLLP.Client.is_connected?(@connections[endpoint]) do
+        MLLP.Client.reconnect(@connections[endpoint])
+      end
+    else
+      # Make a new connection
+      {:ok, client_pid} = MLLP.Client.start_link(ip, port)
+      @connections = Map.put(@connections, endpoint, client_pid)
+    end
+
+    # Send message to the endpoint
+    resp = MLLP.Client.send(@connections[endpoint], message)
 
     Mix.shell().info(inspect(resp))
   end

--- a/lib/mllparty/application.ex
+++ b/lib/mllparty/application.ex
@@ -12,6 +12,8 @@ defmodule MLLParty.Application do
       MLLPartyWeb.Telemetry,
       # Start the PubSub system
       {Phoenix.PubSub, name: MLLParty.PubSub},
+      # Start the ConnectionHub
+      MLLParty.ConnectionHub,
       # Start the Endpoint (http/https)
       MLLPartyWeb.Endpoint
       # Start a worker by calling: MLLParty.Worker.start_link(arg)

--- a/lib/mllparty/connection_hub/client_wrapper.ex
+++ b/lib/mllparty/connection_hub/client_wrapper.ex
@@ -1,0 +1,76 @@
+defmodule MLLParty.ConnectionHub.ClientWrapper do
+  use Supervisor
+
+  @moduledoc """
+  This is a Supervisor that supervises a single `MLLP.Client` process.
+
+  We're wrapping the `MLLP.Client` in a Supervisor so that we can
+  give it a unique process name (`MLLP.Client` isn't name-able out of the box,
+  and we want a unique `MLLP.Client` process for each `{ip, port}` combo so
+  that we only maintain 1 persistent connection per endpoint).
+
+  This will allow us to use the `Registry` to look up the `MLLP.Client`
+  process by name, and send messages to it.
+  """
+
+  require Logger
+
+  def child_spec(ip, port) do
+    %{
+      id: "#{ip}:#{port}",
+      start: {__MODULE__, :start_link, [ip, port]}
+    }
+  end
+
+  def start_link(ip, port) do
+    Supervisor.start_link(__MODULE__, {ip, port}, name: process_name(ip, port))
+  end
+
+  @impl true
+  def init({ip, port}) do
+    children = [
+      %{
+        id: "#{ip}:#{port}",
+        start: {MLLP.Client, :start_link, [ip, port]}
+      }
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def send_message(pid, message) do
+    # We're essentially proxying the message to the `MLLP.Client`
+    # that we're supervising. We need to get the PID of the
+    # `MLLP.Client` process that we're supervising, and then
+    # send the message to (and through) it.
+    pid
+    |> child_client_pid()
+    |> MLLP.Client.send(message)
+  end
+
+  def client_status(wrapper_pid) do
+    # NB: This is relying on the fact that the `MLLP.Client` process id
+    #     defined in child_spec is the same as the endpoint string.
+    [{endpoint, client_pid, _, [MLLP.Client]}] = Supervisor.which_children(wrapper_pid)
+    [ip, port] = String.split(endpoint, ":")
+
+    %{
+      endpoint: endpoint,
+      ip: ip,
+      port: String.to_integer(port),
+      connected: MLLP.Client.is_connected?(client_pid)
+    }
+  end
+
+  def process_name(ip, port) do
+    {:via, Registry, {MLLParty.ConnectionHub.ClientRegistry, "#{ip}:#{port}"}}
+  end
+
+  defp child_client_pid(client_wrapper_pid) do
+    # A little bit of magic here. We're using the `which_children`
+    # function to get the PID of the `MLLP.Client` process that
+    # is being supervised by this `ClientWrapper` process.
+    [{_name, mllp_client_pid, :worker, _module}] = Supervisor.which_children(client_wrapper_pid)
+    mllp_client_pid
+  end
+end

--- a/lib/mllparty/connection_hub/connection_hub.ex
+++ b/lib/mllparty/connection_hub/connection_hub.ex
@@ -1,0 +1,170 @@
+defmodule MLLParty.ConnectionHub do
+  @moduledoc """
+  Root of the ConnectionHub tree, which monitors `MLLP.Client` processes,
+  and dispatches messages to and through the correct `MLLP.Client` process.
+
+  This root is a Supervisor, supervising 2 processes:
+  - a `Registry`
+  - a `DynamicSupervisor` that will supervise all the `ClientWrapper`s
+
+  The supervision tree looks like this:
+  ```
+  MLLParty.ConnectionHub
+  ├── Registry
+  └── DynamicSupervisor
+      ├── ClientWrapper
+      │   └── MLLP.Client (e.g. 127.0.0.1:6090)
+      └── ClientWrapper
+          └── MLLP.Client (e.g. 10.10.10.120:6090)
+  ```
+
+  Upon boot, after this process's 2 children have started, any
+  pre-configured client connections will be started.
+  """
+
+  use Supervisor
+
+  require Logger
+
+  alias MLLParty.ConnectionHub.ClientWrapper
+
+  @default_connection_wait_time Application.compile_env(
+                                  :mllparty,
+                                  :default_connection_wait_time,
+                                  10_000
+                                )
+
+  def start_link(_opts) do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      {DynamicSupervisor, name: MLLPClientSupervisor, strategy: :one_for_one},
+      {Registry, keys: :unique, name: __MODULE__.ClientRegistry},
+      {Task, fn -> start_boot_clients() end}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  @doc """
+  Sends a message to the client connection process for the given `ip` and `port`.
+  """
+  def send_message(ip, port, message, opts \\ []) do
+    pid =
+      case start_client(ip, port) do
+        {:ok, pid} ->
+          pid
+
+        {:error, {:already_started, pid}} ->
+          pid
+      end
+
+    if opts[:wait_for_client_to_connect] do
+      wait_for_client_to_connect(pid)
+    end
+
+    Logger.debug("Sending message to client #{ip}:#{port}: #{inspect(message)}")
+    ClientWrapper.send_message(pid, message)
+  end
+
+  @doc """
+  Returns a list of all client connections, with their status.
+
+  Example:
+
+      iex> MLLParty.ConnectionHub.list_clients()
+      [
+        %{
+          endpoint: "127.0.0.1:6090",
+          ip: "127.0.0.1",
+          port: "6090",
+          connected: true
+        }
+      ]
+  """
+  def list_clients() do
+    for {_name, pid, _, _} <- Supervisor.which_children(MLLPClientSupervisor) do
+      ClientWrapper.client_status(pid)
+    end
+  end
+
+  @doc """
+  Starts a client connection process to the given `ip` and `port`.
+  """
+  def start_client(ip, port) do
+    Logger.info("Starting client connection: #{ip}:#{port}")
+
+    DynamicSupervisor.start_child(
+      MLLPClientSupervisor,
+      MLLParty.ConnectionHub.ClientWrapper.child_spec(ip, port)
+    )
+  end
+
+  @doc """
+  Stops a client connection process to the given `ip` and `port`.
+  """
+  def stop_client(ip, port) when is_binary(ip) do
+    {:via, Registry, {registry_name, process_key}} = ClientWrapper.process_name(ip, port)
+
+    case Registry.lookup(registry_name, process_key) do
+      [] ->
+        Logger.info("Failed to stop client: Client connection not found: #{ip}:#{port}")
+        {:error, :not_found}
+
+      [{client_wrapper_pid, _}] ->
+        DynamicSupervisor.terminate_child(
+          MLLPClientSupervisor,
+          client_wrapper_pid
+        )
+
+        Logger.info("Stopped client: #{ip}:#{port}")
+    end
+  end
+
+  def reset() do
+    for {_name, client_wrapper_pid, _, _} <- Supervisor.which_children(MLLPClientSupervisor) do
+      DynamicSupervisor.terminate_child(
+        MLLPClientSupervisor,
+        client_wrapper_pid
+      )
+    end
+  end
+
+  defp start_boot_clients() do
+    boot_clients = Application.get_env(:mllparty, :boot_clients, [])
+    Logger.info("Starting boot client connections: #{inspect(boot_clients)}")
+
+    for {ip, port} <- boot_clients do
+      start_client(ip, port)
+    end
+  end
+
+  defp wait_for_client_to_connect(
+         client_wrapper_pid,
+         wait_ms \\ @default_connection_wait_time,
+         sleep_interval_ms \\ 300
+       ) do
+    %{endpoint: endpoint, connected: connected} = ClientWrapper.client_status(client_wrapper_pid)
+
+    cond do
+      connected ->
+        :ok
+
+      wait_ms <= 0 ->
+        :timeout
+
+      true ->
+        Logger.info("Waiting for client to connect: #{endpoint}")
+        Process.sleep(sleep_interval_ms)
+
+        wait_for_client_to_connect(
+          client_wrapper_pid,
+          wait_ms - sleep_interval_ms,
+          sleep_interval_ms
+        )
+    end
+  end
+end

--- a/lib/mllparty_web/controllers/connection_controller.ex
+++ b/lib/mllparty_web/controllers/connection_controller.ex
@@ -1,0 +1,9 @@
+defmodule MLLPartyWeb.ConnectionController do
+  use MLLPartyWeb, :controller
+
+  action_fallback MLLPartyWeb.FallbackController
+
+  def list(conn, _params) do
+    json(conn, %{connections: MLLParty.ConnectionHub.list_clients()})
+  end
+end

--- a/lib/mllparty_web/controllers/mllp_message_controller.ex
+++ b/lib/mllparty_web/controllers/mllp_message_controller.ex
@@ -19,12 +19,30 @@ defmodule MLLPartyWeb.MLLPMessageController do
     end
   end
 
+  # Map of persistent connections (endpoint => client pid)
+  # Example { "127.0.0.1:3000" => #PID<1>, "127.0.0.1:4000" => #PID<2> }
+  @connections %{}
+
   def send(conn, %{"endpoint" => endpoint, "message" => message}) do
     with {:ok, {ip, port}} <- validate_endpoint(endpoint),
          %HL7.Message{} = hl7_message <- HL7.Message.new(message) do
-      {:ok, pid} = MLLP.Client.start_link(ip, port)
 
-      case MLLP.Client.send(pid, hl7_message) do
+      # Check for an existing client for this endpoint
+      if Map.has_key?(@connections, endpoint) do
+        # Reconnect to the endpoint, if needed
+        unless MLLP.Client.is_connected?(@connections[endpoint]) do
+          MLLP.Client.reconnect(@connections[endpoint])
+        end
+      else
+        # Make a new connection
+        {:ok, client_pid} = MLLP.Client.start_link(ip, port)
+        @connections = Map.put(@connections, endpoint, client_pid)
+      end
+
+      # Send message to the endpoint
+      resp = MLLP.Client.send(@connections[endpoint], hl7_message)
+
+      case resp do
         {:ok, _} ->
           Logger.info("Message sent successfully to #{ip}:#{port}")
           json(conn, %{sent: true})

--- a/lib/mllparty_web/router.ex
+++ b/lib/mllparty_web/router.ex
@@ -11,6 +11,7 @@ defmodule MLLPartyWeb.Router do
   scope "/api", MLLPartyWeb do
     pipe_through :api
 
+    get "/connections", ConnectionController, :list
     post "/mllp_messages", MLLPMessageController, :send
   end
 

--- a/test/mllparty_web/controllers/connection_controller_test.exs
+++ b/test/mllparty_web/controllers/connection_controller_test.exs
@@ -1,0 +1,74 @@
+defmodule MLLPartyWeb.ConnectionControllerTest do
+  use MLLPartyWeb.ConnCase
+
+  @moduletag capture_log: true
+
+  @api_key "test_sekret"
+  @api_endpoint "/api/connections"
+
+  setup do
+    original_api_key = Application.get_env(:mllparty, :api_key)
+    Application.put_env(:mllparty, :api_key, @api_key)
+
+    authd_conn = build_conn() |> basic_auth("", @api_key)
+
+    on_exit(fn ->
+      MLLParty.ConnectionHub.reset()
+      Application.put_env(:mllparty, :api_key, original_api_key)
+    end)
+
+    {:ok, %{conn: authd_conn}}
+  end
+
+  describe "GET #{@api_endpoint}" do
+    test "with missing API key" do
+      resp =
+        build_conn()
+        |> get(@api_endpoint, %{})
+        |> json_response(401)
+
+      assert resp == %{"message" => "Missing API key"}
+    end
+
+    test "with invalid API key" do
+      resp =
+        build_conn()
+        |> basic_auth("", "invalid")
+        |> get(@api_endpoint, %{})
+        |> json_response(401)
+
+      assert resp == %{"message" => "Invalid API key"}
+    end
+
+    test "when no active connections", %{conn: conn} do
+      conn = get(conn, @api_endpoint)
+      assert json_response(conn, 200)["connections"] == []
+    end
+
+    test "with active connections", %{conn: conn} do
+      {:ok, _r6090} = MLLP.Receiver.start(port: 6090, dispatcher: MLLP.EchoDispatcher)
+
+      MLLParty.ConnectionHub.start_client("127.0.0.1", 6090)
+      MLLParty.ConnectionHub.start_client("127.0.0.1", 6091)
+
+      conn = get(conn, @api_endpoint)
+
+      assert json_response(conn, 200)["connections"] == [
+               %{
+                 "connected" => true,
+                 "endpoint" => "127.0.0.1:6090",
+                 "ip" => "127.0.0.1",
+                 "port" => 6090
+               },
+               %{
+                 "connected" => false,
+                 "endpoint" => "127.0.0.1:6091",
+                 "ip" => "127.0.0.1",
+                 "port" => 6091
+               }
+             ]
+
+      MLLP.Receiver.stop(6090)
+    end
+  end
+end


### PR DESCRIPTION
This works by introducing a process tree to the top of the application.

The process tree looks like this:
```
  MLLParty.ConnectionHub
  ├── Registry
  └── DynamicSupervisor
      ├── ClientWrapper
      │   └── MLLP.Client (e.g. 127.0.0.1:6090)
      └── ClientWrapper
          └── MLLP.Client (e.g. 10.10.10.120:6090)
```

New connections can be added with `MLLParty.ConnectionHub.start_client(ip, port)`. The system will then attempt to maintain an open connection to that endpoint. The system will also ensure that any consumers of that connection share a unique connection, rather than opening one of their own (for example, concurrent HTTP requests to our "send_message" endpoint will not create duplicate connections to the given endpoint).

We will also attempt to wait for a connection to be established prior to sending a message to a new endpoint. The max wait time is 10s, and can be configured with `config :mllparty, default_connection_wait_time: <time in ms>`.

When connections become disconnected, we will attempt to reconnect with increasing backoff time.

This PR also introduces an API endpoint that can be used to instrospect the current connections and their statuses:
```
GET /api/connections

{
  connections: [
    {
      connected: true,
      endpoint: "127.0.0.1:6090",
      ip: "127.0.0.1",
      port: 6090
    },
    {
      connected: false,
      endpoint: "127.0.0.1:6091",
      ip: "127.0.0.1",
      port: 6091
    }
  ]
}
```